### PR TITLE
feat(ci): add automatic docs generation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,7 +1,7 @@
 on:
     push:
-        branches:
-            - main # only for testing, run on v* tag push later
+        tags:
+            - "v*"
 
 jobs:
     docgen:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,7 +25,7 @@ jobs:
               run: cargo doc --release --no-deps
 
             - name: Create index.html for github pages
-              run: echo "<meta http-equiv=\"refresh\" content=\"0; url=Kate\">" > target/doc/index.html
+              run: echo "<meta http-equiv=\"refresh\" content=\"0; url=kate\">" > target/doc/index.html
 
             - name: Copy generated docs to docs folder
               run: cp -r ./target/doc ./docs

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,38 @@
+on:
+    push:
+        branches:
+            - main # only for testing, run on v* tag push later
+
+jobs:
+    docgen:
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Checkout docs branch
+              uses: actions/checkout@v3
+              with:
+                  ref: docs
+
+            - name: Install latest stable rust toolchain
+              uses: actions-rs/toolchain@v1
+              with:
+                  toolchain: stable
+                  default: true
+                  override: true
+
+            - name: Generate docs
+              run: cargo doc --release --no-deps
+
+            - name: Move generated docs to docs folder
+              run: mv ./target/doc ./docs
+
+            - name: Commit updated documentation
+              run: |
+                  git add ./docs/
+                  git commit -m "docs: generate documentation"
+
+            - name: Push
+              uses: ad-m/github-push-action@master
+              with:
+                  github_token: ${{ secrets.GITHUB_TOKEN }}
+                  branch: docs

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,8 +10,6 @@ jobs:
         steps:
             - name: Checkout docs branch
               uses: actions/checkout@v3
-              with:
-                  ref: docs
 
             - name: Install latest stable rust toolchain
               uses: actions-rs/toolchain@v1

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,7 +25,7 @@ jobs:
               run: cargo doc --release --no-deps
 
             - name: Create index.html for github pages
-              run: echo "<meta http-equiv=\"refresh\" content=\"0; url=jvm\">" > target/doc/index.html
+              run: echo "<meta http-equiv=\"refresh\" content=\"0; url=Kate\">" > target/doc/index.html
 
             - name: Copy generated docs to docs folder
               run: cp -r ./target/doc ./docs

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,11 +20,17 @@ jobs:
                   default: true
                   override: true
 
+            - name: Delete existing docs directory
+              run: rm -rf ./docs/
+
             - name: Generate docs
               run: cargo doc --release --no-deps
 
-            - name: Move generated docs to docs folder
-              run: mv ./target/doc ./docs
+            - name: Create index.html for github pages
+              run: echo "<meta http-equiv=\"refresh\" content=\"0; url=jvm\">" > target/doc/index.html
+
+            - name: Copy generated docs to docs folder
+              run: cp -r ./target/doc ./docs
 
             - name: Commit updated documentation
               uses: stefanzweifel/git-auto-commit-action@v4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,12 +27,6 @@ jobs:
               run: mv ./target/doc ./docs
 
             - name: Commit updated documentation
-              run: |
-                  git add ./docs/
-                  git commit -m "docs: generate documentation"
-
-            - name: Push
-              uses: ad-m/github-push-action@master
+              uses: stefanzweifel/git-auto-commit-action@v4
               with:
-                  github_token: ${{ secrets.GITHUB_TOKEN }}
-                  branch: docs
+                  commit_message: "docs: autogenerate documentation"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,11 +4,11 @@ on:
             - "v*"
 
 jobs:
-    docgen:
+    generate-docs:
         runs-on: ubuntu-latest
 
         steps:
-            - name: Checkout docs branch
+            - name: Checkout
               uses: actions/checkout@v3
 
             - name: Install latest stable rust toolchain

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,7 +7,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
 
             - name: Install latest stable rust toolchain
               uses: actions-rs/toolchain@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
 
             - name: Install latest stable rust toolchain
               uses: actions-rs/toolchain@v1


### PR DESCRIPTION
## Confirmation
- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines](https://github.com/nullishamy/JVM/blob/main/CONTRIBUTING.MD)

### Changes

- [ ] Internal
- [ ] Feature
- [ ] Documentation
- [x] Other: CI actions workflow

<!-- Replace "NaN" with an issue number (in the #123 format) if this is a response to an issue -->

Closes Issue: #22 

## Description

Add an actions workflow to generate documentation (using `cargo doc`) and host it on GitHub pages. Runs on the same triggers as the release workflow, and uses the code from the tagged commit. There's a preview available on my repository's page: https://dheerajpv.github.io/JVM/
