### PR TITLE
Style improvements

### DIFF
--- a/src/classfile/parse.rs
+++ b/src/classfile/parse.rs
@@ -43,7 +43,7 @@ impl ClassFileParser {
         if path.starts_with("java/") {
             debug!("java stdlib detected, altering path");
 
-            path = format!("src/stdlib/{}", path)
+            path = format!("src/stdlib/{}", path);
         }
 
         path += ".class";

--- a/src/classfile/parse.rs
+++ b/src/classfile/parse.rs
@@ -22,7 +22,7 @@ impl ClassFileParser {
     pub fn from_path(path: String) -> Result<Self> {
         info!("opening classfile '{}' for parsing from path", path);
 
-        let buffer = ClassFileParser::bytes(path.to_owned())?;
+        let buffer = ClassFileParser::bytes(path.clone())?;
         Ok(ClassFileParser::from_bytes(path, buffer))
     }
 

--- a/src/classfile/parse_helper.rs
+++ b/src/classfile/parse_helper.rs
@@ -247,9 +247,9 @@ pub fn parse_method_info(parser: &mut ClassFileParser, length: u16) -> Result<Ve
 }
 
 /**
-This macro builds a set of try_get_{number_type} functions for safe reading of
+This macro builds a set of `try_get_{number_type}` functions for safe reading of
 bytes from a Bytes object. They return Result<T> instead of panicking
- **/
+ */
 macro_rules! impl_safebuf {
     ( $($type:ty),* ) => {
         pub trait SafeBuf: bytes::Buf {

--- a/src/classfile/parse_helper.rs
+++ b/src/classfile/parse_helper.rs
@@ -246,10 +246,8 @@ pub fn parse_method_info(parser: &mut ClassFileParser, length: u16) -> Result<Ve
     Ok(out)
 }
 
-/**
-This macro builds a set of `try_get_{number_type}` functions for safe reading of
-bytes from a Bytes object. They return Result<T> instead of panicking
- */
+/// This macro builds a set of `try_get_{number_type}` functions for safe reading of
+/// bytes from a Bytes object. They return Result<T> instead of panicking
 macro_rules! impl_safebuf {
     ( $($type:ty),* ) => {
         pub trait SafeBuf: bytes::Buf {

--- a/src/classfile/parse_helper.rs
+++ b/src/classfile/parse_helper.rs
@@ -240,7 +240,7 @@ pub fn parse_method_info(parser: &mut ClassFileParser, length: u16) -> Result<Ve
             descriptor_index,
             attributes_count,
             attribute_info,
-        })
+        });
     }
 
     Ok(out)

--- a/src/error/internal.rs
+++ b/src/error/internal.rs
@@ -31,14 +31,14 @@ impl InternalData {
     pub fn message(&self) -> String {
         self.message
             .as_ref()
-            .map_or("unknown", |m| m.as_str())
+            .map_or("unknown", String::as_str)
             .to_owned()
     }
 
     pub fn file(&self) -> String {
         self.source_file
             .as_ref()
-            .map_or("unknown", |m| m.as_str())
+            .map_or("unknown", String::as_str)
             .to_owned()
     }
 }

--- a/src/interface/tui.rs
+++ b/src/interface/tui.rs
@@ -164,7 +164,7 @@ pub fn start_tui(
                         state.log_lines.push_back(msg);
                     }
                     TuiCommand::Refresh => {
-                        //no-op, this just causes a re-render
+                        // no-op, this just causes a re-render
                     }
                     TuiCommand::VmState(new_status) => {
                         state.vm_state = new_status;
@@ -338,7 +338,7 @@ where
         .log_lines
         .iter()
         .map(|msg| {
-            //TODO: make this more robust
+            // TODO: make this more robust
             let msg = msg.strip_prefix(' ').unwrap_or(msg);
             let (level, style) = if msg.starts_with("INFO") {
                 ("INFO", info_style)

--- a/src/main.rs
+++ b/src/main.rs
@@ -136,7 +136,7 @@ fn start(vm: &Vm, main_class_path: &str) -> Result<()> {
                 .unwrap()
                 .as_array()
                 .filter(|p| {
-                    p._type
+                    p.type_
                         .as_reference()
                         .filter(|a| a.internal_name == "java/lang/String")
                         .is_some()

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,8 +39,8 @@ async fn main() -> Result<()> {
     let cmd = args.command;
 
     let (write, read) = tokio::sync::mpsc::unbounded_channel::<TuiCommand>();
-    //TODO: start runtime with these channels to pass messages to tui
-    //this will no-op if TUI is not enabled as nothing is listening
+    // TODO: start runtime with these channels to pass messages to tui
+    // this will no-op if TUI is not enabled as nothing is listening
 
     let mut tui: Option<TuiWriter> = None;
 

--- a/src/runtime/classload/loader.rs
+++ b/src/runtime/classload/loader.rs
@@ -47,11 +47,13 @@ where
         let mut root = self.parent();
 
         while let Some(parent) = root {
-            if let Some(loaded) = parent.read().unwrap().find_loaded_class(internal_name) {
+            let lock = parent.read().unwrap();
+
+            if let Some(loaded) = lock.find_loaded_class(internal_name) {
                 return Ok(loaded);
             }
 
-            root = parent.read().unwrap().parent();
+            root = lock.parent();
         }
 
         self.define_class(self.find_class(internal_name)?)

--- a/src/runtime/classload/system.rs
+++ b/src/runtime/classload/system.rs
@@ -49,14 +49,9 @@ impl ClassLoader<SystemClassLoader> for SystemClassLoader {
 
     fn define_class(&mut self, data: ClassDefinition) -> Result<Arc<LoadedClassFile>> {
         let name = data.internal_name;
-
-        if name.is_none() {
-            return Err(anyhow!(
-                "name was not present, and anonymous classes are not supported yet"
-            ));
-        }
-
-        let name = name.unwrap();
+        let name = name.ok_or_else(|| {
+            anyhow!("name was not present, and anonymous classes are not supported yet")
+        })?;
 
         let res =
             LoadedClassFile::from_raw(ClassFileParser::from_bytes(name, data.bytes).parse()?)?;

--- a/src/runtime/heap/mod.rs
+++ b/src/runtime/heap/mod.rs
@@ -60,22 +60,19 @@ impl Heap {
         let mut counter = 0;
 
         // Iterate through the indices of weak references without any corresponding strong references
-        let dead_refs: Vec<usize> = self
-            .refs
-            .iter()
-            .enumerate()
-            .filter(|(_i, e)| e.strong_count() == 0)
-            .map(|(i, _)| i)
-            .rev()
-            .collect();
-
-        for dead in dead_refs {
-            self.refs.swap_remove(dead);
-            counter += 1;
-        }
+        self.refs.retain(|e| {
+            if e.strong_count() == 0 {
+                counter += 1;
+                false
+            } else {
+                true
+            }
+        });
 
         // even though we still have the allocation, we dont own the value
         // and it cannot be used, so we consider it unused
+        // TODO: Can we just set this to size after pruning?
+        // Or if not, maybe consider comparing size before and after, seems less error-prone.
         self.used -= counter;
 
         // TODO: determine when we should de-allocate, this shouldnt be done often as

--- a/src/runtime/heap/mod.rs
+++ b/src/runtime/heap/mod.rs
@@ -96,18 +96,10 @@ impl Heap {
 
     pub fn get(&self, ptr: &JvmPointer) -> Result<Arc<JvmObject>> {
         let obj = self.refs.get(*ptr as usize);
-
-        if obj.is_none() {
-            return Err(anyhow!("could not locate object for ptr {}", ptr));
-        }
-
-        let obj = obj.unwrap().upgrade();
-
-        if obj.is_none() {
-            return Err(anyhow!("could not upgrade object for ptr {}", ptr));
-        }
-
-        Ok(obj.unwrap())
+        let obj = obj
+            .ok_or_else(|| anyhow!("could not locate object for ptr {}", ptr))?
+            .upgrade();
+        obj.ok_or_else(|| anyhow!("could not upgrade object for ptr {}", ptr))
     }
 
     pub fn total(&self) -> usize {

--- a/src/runtime/instruction/aload.rs
+++ b/src/runtime/instruction/aload.rs
@@ -15,8 +15,8 @@ pub fn aload(_vm: &Vm, ctx: &mut CallSite, idx: u16) -> Result<()> {
     let local = sf.locals.get(idx as usize);
 
     if let Some(local) = local {
-        if let StackValue::Reference(_ref) = local {
-            ops.push(StackValue::Reference(_ref.clone()));
+        if let StackValue::Reference(ref_) = local {
+            ops.push(StackValue::Reference(ref_.clone()));
             debug!("pushed local to the op stack");
             Ok(())
         } else {

--- a/src/runtime/instruction/areturn.rs
+++ b/src/runtime/instruction/areturn.rs
@@ -13,7 +13,6 @@ pub fn areturn(_vm: &Vm, ctx: &mut CallSite, _bytes: &mut Bytes) -> Result<()> {
     let ref_value = sf.operand_stack.pop();
     let ref_value = ref_value.ok_or_else(|| anyhow!("operand stack was empty"))?;
 
-    // TODO: I don't quite understand this, "operand stack was empty" is an error, and operand stack not empty is a warn?
     if !sf.operand_stack.is_empty() {
         warn!("attempted to areturn with values on the operand stack");
         sf.operand_stack.discard();

--- a/src/runtime/instruction/areturn.rs
+++ b/src/runtime/instruction/areturn.rs
@@ -11,41 +11,29 @@ pub fn areturn(_vm: &Vm, ctx: &mut CallSite, _bytes: &mut Bytes) -> Result<()> {
     let mut sf = lock.pop().expect("call stack was empty?");
 
     let ref_value = sf.operand_stack.pop();
+    let ref_value = ref_value.ok_or_else(|| anyhow!("operand stack was empty"))?;
 
-    if ref_value.is_none() {
-        return Err(anyhow!("operand stack was empty"));
-    }
-
+    // TODO: I don't quite understand this, "operand stack was empty" is an error, and operand stack not empty is a warn?
     if !sf.operand_stack.is_empty() {
         warn!("attempted to areturn with values on the operand stack");
         sf.operand_stack.discard();
     }
 
-    let ref_value = ref_value.unwrap();
     let ref_value = ref_value.as_reference();
-
-    if ref_value.is_none() {
-        return Err(anyhow!("ref value was not a reference"));
-    }
-
-    let ref_value = ref_value.unwrap();
+    let ref_value = ref_value.ok_or_else(|| anyhow!("ref value was not a reference"))?;
 
     debug!("dropped a stackframe from the callstack");
     *ctx.pc.write() = 0;
 
     let caller = lock.peek_mut();
-
-    if caller.is_none() {
-        return Err(anyhow!("attempted to return from method with no caller?"));
-    }
+    let caller =
+        caller.ok_or_else(|| anyhow!("attempted to return from method with no caller?"))?;
 
     let value = if ref_value.is_null() {
         ReferenceType::Null
     } else {
         ReferenceType::Class(Arc::clone(ref_value.as_class().expect("unreachable")))
     };
-
-    let caller = caller.unwrap();
 
     debug!("pushed the reference onto the caller's op stack");
     caller.operand_stack.push(RefOrPrim::Reference(value));

--- a/src/runtime/instruction/astore.rs
+++ b/src/runtime/instruction/astore.rs
@@ -11,11 +11,11 @@ pub fn astore(_vm: &Vm, ctx: &mut CallSite, idx: u16) -> Result<()> {
 
     debug!("storing ref into {}", idx);
 
-    let _ref = sf.operand_stack.pop();
-    let _ref = _ref.ok_or_else(|| anyhow!("op stack was empty"))?;
+    let ref_ = sf.operand_stack.pop();
+    let ref_ = ref_.ok_or_else(|| anyhow!("op stack was empty"))?;
 
-    if let StackValue::Reference(_ref) = _ref {
-        sf.locals.insert(idx as usize, StackValue::Reference(_ref));
+    if let StackValue::Reference(ref_) = ref_ {
+        sf.locals.insert(idx as usize, StackValue::Reference(ref_));
         debug!("stored local");
         Ok(())
     } else {

--- a/src/runtime/instruction/astore.rs
+++ b/src/runtime/instruction/astore.rs
@@ -12,16 +12,13 @@ pub fn astore(_vm: &Vm, ctx: &mut CallSite, idx: u16) -> Result<()> {
     debug!("storing ref into {}", idx);
 
     let _ref = sf.operand_stack.pop();
+    let _ref = _ref.ok_or_else(|| anyhow!("op stack was empty"))?;
 
-    if let Some(local) = _ref {
-        if let StackValue::Reference(_ref) = local {
-            sf.locals.insert(idx as usize, StackValue::Reference(_ref));
-            debug!("stored local");
-            Ok(())
-        } else {
-            Err(anyhow!("value was not a reference, invalid bytecode"))
-        }
+    if let StackValue::Reference(_ref) = _ref {
+        sf.locals.insert(idx as usize, StackValue::Reference(_ref));
+        debug!("stored local");
+        Ok(())
     } else {
-        Err(anyhow!("op stack was empty"))
+        Err(anyhow!("value was not a reference, invalid bytecode"))
     }
 }

--- a/src/runtime/instruction/dup.rs
+++ b/src/runtime/instruction/dup.rs
@@ -9,14 +9,9 @@ pub fn dup(_vm: &Vm, ctx: &mut CallSite, _bytes: &mut Bytes) -> Result<()> {
     let st = &mut sf.operand_stack;
 
     let v = st.peek();
+    let v = v.ok_or_else(|| anyhow!("operand stack was empty"))?.clone();
 
-    if v.is_none() {
-        return Err(anyhow!("operand stack was empty"));
-    }
-
-    let v2 = v.unwrap().clone();
-
-    st.push(v2);
+    st.push(v);
 
     Ok(())
 }

--- a/src/runtime/instruction/getstatic.rs
+++ b/src/runtime/instruction/getstatic.rs
@@ -18,16 +18,9 @@ pub fn get_static(vm: &Vm, ctx: &mut CallSite, bytes: &mut Bytes) -> Result<()> 
     let class = loader.load_class(class_name)?;
 
     let lock = class.fields.read();
-    let field_data = lock.statics.get(&field_ref.name_and_type.name.str);
-
-    if field_data.is_none() {
-        return Err(anyhow!(
-            "unknown static field {}",
-            field_ref.name_and_type.name.str
-        ));
-    }
-
-    let field_obj = field_data.unwrap();
+    let field_obj = lock.statics.get(&field_ref.name_and_type.name.str);
+    let field_obj = field_obj
+        .ok_or_else(|| anyhow!("unknown static field {}", field_ref.name_and_type.name.str))?;
 
     let stack = &mut sf.operand_stack;
 

--- a/src/runtime/instruction/ifnull.rs
+++ b/src/runtime/instruction/ifnull.rs
@@ -21,12 +21,8 @@ pub fn ifnull(vm: &Vm, ctx: &mut CallSite, args: &mut Args, bytes: &mut Bytes) -
 
     let obj_ref = obj_ref.unwrap();
     let obj_ref = obj_ref.as_reference();
+    let obj_ref = obj_ref.ok_or_else(|| anyhow!("obj ref was a primitive, expected reference"))?;
 
-    if obj_ref.is_none() {
-        return Err(anyhow!("obj ref was a primitive, expected reference"));
-    }
-
-    let obj_ref = obj_ref.unwrap();
     let obj_ref = obj_ref.as_class();
 
     if obj_ref.is_none() {

--- a/src/runtime/instruction/iload.rs
+++ b/src/runtime/instruction/iload.rs
@@ -15,27 +15,23 @@ pub fn iload(_vm: &Vm, ctx: &mut CallSite, idx: u16) -> Result<()> {
     let ops = &mut sf.operand_stack;
     let local = sf.locals.get(idx as usize);
 
-    if let Some(local) = local {
-        if let StackValue::Primitive(_ref) = local {
-            if let PrimitiveWithValue::Int(i) = _ref {
-                ops.push(StackValue::Primitive(PrimitiveWithValue::Int(*i)));
-                debug!("pushed int {:?} to the op stack", _ref);
-                Ok(())
-            } else {
-                Err(anyhow!(
-                    "local @ idx {} was not an int, invalid bytecode",
-                    idx
-                ))
-            }
+    let local =
+        local.ok_or_else(|| anyhow!("local @ idx {} did not exist, invalid bytecode", idx))?;
+
+    if let StackValue::Primitive(_ref) = local {
+        if let PrimitiveWithValue::Int(i) = _ref {
+            ops.push(StackValue::Primitive(PrimitiveWithValue::Int(*i)));
+            debug!("pushed int {:?} to the op stack", _ref);
+            Ok(())
         } else {
             Err(anyhow!(
-                "local @ idx {} was not a primitive, invalid bytecode",
+                "local @ idx {} was not an int, invalid bytecode",
                 idx
             ))
         }
     } else {
         Err(anyhow!(
-            "local @ idx {} did not exist, invalid bytecode",
+            "local @ idx {} was not a primitive, invalid bytecode",
             idx
         ))
     }

--- a/src/runtime/instruction/iload.rs
+++ b/src/runtime/instruction/iload.rs
@@ -18,10 +18,10 @@ pub fn iload(_vm: &Vm, ctx: &mut CallSite, idx: u16) -> Result<()> {
     let local =
         local.ok_or_else(|| anyhow!("local @ idx {} did not exist, invalid bytecode", idx))?;
 
-    if let StackValue::Primitive(_ref) = local {
-        if let PrimitiveWithValue::Int(i) = _ref {
+    if let StackValue::Primitive(ref_) = local {
+        if let PrimitiveWithValue::Int(i) = ref_ {
             ops.push(StackValue::Primitive(PrimitiveWithValue::Int(*i)));
-            debug!("pushed int {:?} to the op stack", _ref);
+            debug!("pushed int {:?} to the op stack", ref_);
             Ok(())
         } else {
             Err(anyhow!(

--- a/src/runtime/instruction/invokespecial.rs
+++ b/src/runtime/instruction/invokespecial.rs
@@ -56,7 +56,6 @@ pub fn invoke_special(vm: &Vm, ctx: &mut CallSite, bytes: &mut Bytes) -> Result<
 
     // drop the lock before re-interpreting in case 'method' invokes invokespecial again
     // if we didnt do this, we could deadlock
-    // we use this if/else to definitely drop before we interpret anything
     drop(lock);
     if cls.requires_clinit() {
         cls.run_clinit(

--- a/src/runtime/instruction/invokespecial.rs
+++ b/src/runtime/instruction/invokespecial.rs
@@ -69,7 +69,7 @@ pub fn invoke_special(vm: &Vm, ctx: &mut CallSite, bytes: &mut Bytes) -> Result<
         )?;
     }
 
-    //TODO: respect polymorphic calls
+    // TODO: respect polymorphic calls
     // replace '&cls' with obj_ref's class once we figure out polymorphism
     vm.interpret(
         CallSite::new(

--- a/src/runtime/instruction/invokespecial.rs
+++ b/src/runtime/instruction/invokespecial.rs
@@ -57,8 +57,8 @@ pub fn invoke_special(vm: &Vm, ctx: &mut CallSite, bytes: &mut Bytes) -> Result<
     // drop the lock before re-interpreting in case 'method' invokes invokespecial again
     // if we didnt do this, we could deadlock
     // we use this if/else to definitely drop before we interpret anything
+    drop(lock);
     if cls.requires_clinit() {
-        drop(lock);
         cls.run_clinit(
             vm,
             CallSite::new(
@@ -68,8 +68,6 @@ pub fn invoke_special(vm: &Vm, ctx: &mut CallSite, bytes: &mut Bytes) -> Result<
                 Some(Arc::clone(&obj_ref)),
             ),
         )?;
-    } else {
-        drop(lock);
     }
 
     //TODO: respect polymorphic calls

--- a/src/runtime/instruction/invokestatic.rs
+++ b/src/runtime/instruction/invokestatic.rs
@@ -57,8 +57,8 @@ pub fn invoke_static(vm: &Vm, ctx: &mut CallSite, bytes: &mut Bytes) -> Result<(
 
     let args = create_args(&method.descriptor, &mut sf.operand_stack)?;
 
+    drop(lock);
     if cls.requires_clinit() {
-        drop(lock);
         cls.run_clinit(
             vm,
             CallSite::new(
@@ -68,8 +68,6 @@ pub fn invoke_static(vm: &Vm, ctx: &mut CallSite, bytes: &mut Bytes) -> Result<(
                 None,
             ),
         )?;
-    } else {
-        drop(lock)
     }
 
     // interpret on the same thread, using a different class

--- a/src/runtime/instruction/invokestatic.rs
+++ b/src/runtime/instruction/invokestatic.rs
@@ -47,11 +47,8 @@ pub fn invoke_static(vm: &Vm, ctx: &mut CallSite, bytes: &mut Bytes) -> Result<(
 
     let method = cls.methods.read().find(|m| m.name.str == nt.name.str);
 
-    if method.is_none() {
-        return Err(anyhow!("could not resolve static method '{}'", nt.name.str));
-    }
-
-    let method = method.unwrap();
+    let method =
+        method.ok_or_else(|| anyhow!("could not resolve static method '{}'", nt.name.str))?;
 
     debug!(
         "INVOKESTATIC: {} {} {}",

--- a/src/runtime/instruction/invokevirtual.rs
+++ b/src/runtime/instruction/invokevirtual.rs
@@ -55,8 +55,6 @@ pub fn invoke_virtual(vm: &Vm, ctx: &mut CallSite, bytes: &mut Bytes) -> Result<
 
     // drop the lock before re-interpreting in case 'method' invokes invokespecial again
     // if we didnt do this, we could deadlock
-    // we use this if/else to definitely drop before we interpret anything
-
     drop(lock);
     if cls.requires_clinit() {
         cls.run_clinit(

--- a/src/runtime/instruction/invokevirtual.rs
+++ b/src/runtime/instruction/invokevirtual.rs
@@ -57,8 +57,8 @@ pub fn invoke_virtual(vm: &Vm, ctx: &mut CallSite, bytes: &mut Bytes) -> Result<
     // if we didnt do this, we could deadlock
     // we use this if/else to definitely drop before we interpret anything
 
+    drop(lock);
     if cls.requires_clinit() {
-        drop(lock);
         cls.run_clinit(
             vm,
             CallSite::new(
@@ -68,8 +68,6 @@ pub fn invoke_virtual(vm: &Vm, ctx: &mut CallSite, bytes: &mut Bytes) -> Result<
                 Some(Arc::clone(&obj_ref)),
             ),
         )?;
-    } else {
-        drop(lock);
     }
 
     vm.interpret(

--- a/src/runtime/instruction/invokevirtual.rs
+++ b/src/runtime/instruction/invokevirtual.rs
@@ -17,11 +17,7 @@ pub fn invoke_virtual(vm: &Vm, ctx: &mut CallSite, bytes: &mut Bytes) -> Result<
     let entry = ctx.class.const_pool.get(idx.into())?;
     let data = entry.data.as_method_ref();
 
-    if data.is_none() {
-        return Err(anyhow!("expected method ref, got {:?}", entry));
-    }
-
-    let method = data.unwrap();
+    let method = data.ok_or_else(|| anyhow!("expected method ref, got {:?}", entry))?;
 
     let nt = Arc::clone(&method.name_and_type);
     let cls = Arc::clone(&method.class);
@@ -29,15 +25,13 @@ pub fn invoke_virtual(vm: &Vm, ctx: &mut CallSite, bytes: &mut Bytes) -> Result<
 
     let method = cls.methods.read().find(|f| f.name.str == nt.name.str);
 
-    if method.is_none() {
-        return Err(anyhow!(
+    let method = method.ok_or_else(|| {
+        anyhow!(
             "could not find method {} for class {}",
             nt.name.str,
             cls.this_class.name.str
-        ));
-    }
-
-    let method = method.unwrap();
+        )
+    })?;
 
     debug!(
         "INVOKEVIRTUAL: {} {} {}",
@@ -50,25 +44,14 @@ pub fn invoke_virtual(vm: &Vm, ctx: &mut CallSite, bytes: &mut Bytes) -> Result<
     // it should be the only value left after args have been popped off
     let obj_ref = sf.operand_stack.pop();
 
-    if obj_ref.is_none() {
-        return Err(anyhow!("operand stack was empty"));
-    }
-
-    let obj_ref = obj_ref.unwrap();
+    let obj_ref = obj_ref.ok_or_else(|| anyhow!("operand stack was empty"))?;
     let obj_ref = obj_ref.as_reference();
 
-    if obj_ref.is_none() {
-        return Err(anyhow!("obj ref was a primitive, expected reference"));
-    }
-
-    let obj_ref = obj_ref.unwrap();
+    let obj_ref = obj_ref.ok_or_else(|| anyhow!("obj ref was a primitive, expected reference"))?;
     let obj_ref = obj_ref.as_class();
+    let obj_ref = obj_ref.ok_or_else(|| anyhow!("obj ref was a null, expected class"))?;
 
-    if obj_ref.is_none() {
-        return Err(anyhow!("obj ref was a null, expected class"));
-    }
-
-    let obj_ref = Arc::clone(obj_ref.unwrap());
+    let obj_ref = Arc::clone(obj_ref);
 
     // drop the lock before re-interpreting in case 'method' invokes invokespecial again
     // if we didnt do this, we could deadlock

--- a/src/runtime/instruction/ldc.rs
+++ b/src/runtime/instruction/ldc.rs
@@ -46,7 +46,7 @@ pub fn ldc(vm: &Vm, ctx: &mut CallSite, bytes: &mut Bytes) -> Result<()> {
                     .filter(|f| {
                         f.as_array()
                             .filter(|a| {
-                                a._type
+                                a.type_
                                     .as_primitive()
                                     .filter(|p| **p == PrimitiveType::Char)
                                     .is_some()

--- a/src/runtime/instruction/new.rs
+++ b/src/runtime/instruction/new.rs
@@ -19,11 +19,7 @@ pub fn new(vm: &Vm, ctx: &mut CallSite, bytes: &mut Bytes) -> Result<()> {
 
     let data = &entry.data.as_class();
 
-    if data.is_none() {
-        return Err(anyhow!("expected class data, got {:?}", entry));
-    }
-
-    let cls = data.unwrap();
+    let cls = data.ok_or_else(|| anyhow!("expected class data, got {:?}", entry))?;
 
     let cls = vm
         .system_classloader

--- a/src/runtime/instruction/util.rs
+++ b/src/runtime/instruction/util.rs
@@ -27,6 +27,7 @@ pub fn create_args(
         let from_t = from.get_type();
         let from_t = from_t.as_ref();
 
+        // FIXME: logic error - if from_t is None, the type wasn't a reference type, but a primitive
         if from_t.is_none() {
             // null case
             // pop because its quicker & more accurate.

--- a/src/runtime/instruction/util.rs
+++ b/src/runtime/instruction/util.rs
@@ -35,7 +35,7 @@ pub fn create_args(
             args.push(
                 ops.pop()
                     .expect("somehow we could not pop the value? we just peeked it though..."),
-            )
+            );
         }
 
         let from_t = from_t.unwrap();
@@ -45,7 +45,7 @@ pub fn create_args(
             args.push(
                 ops.pop()
                     .expect("somehow we could not pop the value? we just peeked it though..."),
-            )
+            );
         } else {
             // invalid type
             return Err(anyhow!(

--- a/src/runtime/stack.rs
+++ b/src/runtime/stack.rs
@@ -15,7 +15,7 @@ where
     T: Debug + Clone,
 {
     pub fn push(&mut self, value: T) {
-        self.items.push(value)
+        self.items.push(value);
     }
 
     pub fn pop(&mut self) -> Option<T> {
@@ -35,7 +35,7 @@ where
     }
 
     pub fn discard(&mut self) {
-        self.items.clear()
+        self.items.clear();
     }
 
     pub fn len(&self) -> usize {

--- a/src/runtime/stack.rs
+++ b/src/runtime/stack.rs
@@ -12,7 +12,7 @@ where
 
 impl<T> Stack<T>
 where
-    T: Debug + Clone,
+    T: Debug,
 {
     pub fn push(&mut self, value: T) {
         self.items.push(value);
@@ -42,16 +42,8 @@ where
         self.items.len()
     }
 
-    pub fn clone(&self) -> Stack<T> {
-        let items = self.items.clone();
-
-        Self { items }
-    }
-
-    pub fn flip(&mut self) -> &Stack<T> {
+    pub fn flip(&mut self) {
         self.items.reverse();
-
-        self
     }
 
     pub fn raw(self) -> Vec<T> {

--- a/src/runtime/threading/thread.rs
+++ b/src/runtime/threading/thread.rs
@@ -48,7 +48,7 @@ impl VmThread {
             Some(this),
         );
 
-        //TODO: change this to async once we implement async interpretation
+        // TODO: change this to async once we implement async interpretation
         spawn_blocking(|| {
             // any blocking operations will get transformed into async ones here, hopefully
             // in order for this to work, the entire interpreter needs to be async
@@ -70,7 +70,7 @@ pub struct StackFrame {
 
 impl StackFrame {
     pub fn new(callsite: CallSite) -> Self {
-        //FIXME: use attrs to determine these
+        // FIXME: use attrs to determine these
         Self {
             operand_stack: Stack::new(),
             locals: Vec::with_capacity(30),

--- a/src/runtime/vm.rs
+++ b/src/runtime/vm.rs
@@ -129,7 +129,7 @@ impl Vm {
             if let Some(this_ref) = this_ref {
                 // push thisref as the first local if it exists. it might not (statics)
                 f.locals
-                    .push(RefOrPrim::Reference(ReferenceType::Class(this_ref)))
+                    .push(RefOrPrim::Reference(ReferenceType::Class(this_ref)));
             }
 
             while let Some(arg) = args.entries.pop() {

--- a/src/runtime/vm.rs
+++ b/src/runtime/vm.rs
@@ -97,7 +97,7 @@ impl Vm {
             );
         }
 
-        //TODO: stackframe support for native functions
+        // TODO: stackframe support for native functions
         if method.access_flags.has(MethodAccessFlag::NATIVE) {
             // f/q/c/n.methodName:(descriptor)
             let name = format!(

--- a/src/stdlib/visitors.rs
+++ b/src/stdlib/visitors.rs
@@ -60,10 +60,8 @@ pub fn visit_system(class: Arc<LoadedClassFile>) {
     let m = entries
         .iter()
         .enumerate()
-        .filter(|(_i, p)| p.name.str == "getSecurityManager")
+        .find(|(_i, p)| p.name.str == "getSecurityManager")
         .map(|(i, _p)| i)
-        .collect::<Vec<usize>>()
-        .first()
         .unwrap();
 
     entries.remove(m);
@@ -103,10 +101,8 @@ pub fn visit_shutdown(class: Arc<LoadedClassFile>) {
     let m = entries
         .iter()
         .enumerate()
-        .filter(|(_i, p)| p.name.str == "<clinit>")
+        .find(|(_i, p)| p.name.str == "<clinit>")
         .map(|(i, _p)| i)
-        .collect::<Vec<usize>>()
-        .first()
         .unwrap();
 
     entries.remove(m);
@@ -139,10 +135,8 @@ pub fn visit_shutdown(class: Arc<LoadedClassFile>) {
     let m = entries
         .iter()
         .enumerate()
-        .filter(|(_i, p)| p.name.str == "exit")
+        .find(|(_i, p)| p.name.str == "exit")
         .map(|(i, _p)| i)
-        .collect::<Vec<usize>>()
-        .first()
         .unwrap();
 
     entries.remove(m);

--- a/src/stdlib/visitors.rs
+++ b/src/stdlib/visitors.rs
@@ -162,5 +162,5 @@ pub fn visit_shutdown(class: Arc<LoadedClassFile>) {
         attributes: Attributes { entries: vec![] },
     }));
 
-    debug!("finished writing to java/lang/Shutdown")
+    debug!("finished writing to java/lang/Shutdown");
 }

--- a/src/stdlib/visitors.rs
+++ b/src/stdlib/visitors.rs
@@ -83,7 +83,7 @@ pub fn visit_system(class: Arc<LoadedClassFile>) {
                 max_stack: 0,
                 max_locals: 0,
                 // return null, this will bypass the checks
-                //FIXME hack
+                // FIXME hack
                 code: vec![1, 176],
                 exception_handlers: vec![],
                 attributes: vec![],
@@ -124,7 +124,7 @@ pub fn visit_shutdown(class: Arc<LoadedClassFile>) {
                 max_stack: 0,
                 max_locals: 0,
                 // return null, this will bypass the checks
-                //FIXME hack
+                // FIXME hack
                 code: vec![177],
                 exception_handlers: vec![],
                 attributes: vec![],

--- a/src/stdlib/visitors.rs
+++ b/src/stdlib/visitors.rs
@@ -54,10 +54,10 @@ pub fn visit_system(class: Arc<LoadedClassFile>) {
         RefOrPrim::Reference(ReferenceType::Class(Arc::new(sysout))),
     );
 
-    let m = *class
-        .methods
-        .read()
-        .entries
+    let mut lock = class.methods.write();
+    let entries = &mut lock.entries;
+
+    let m = entries
         .iter()
         .enumerate()
         .filter(|(_i, p)| p.name.str == "getSecurityManager")
@@ -66,9 +66,9 @@ pub fn visit_system(class: Arc<LoadedClassFile>) {
         .first()
         .unwrap();
 
-    class.methods.write().entries.remove(m);
+    entries.remove(m);
 
-    class.methods.write().entries.push(Arc::new(MethodEntry {
+    entries.push(Arc::new(MethodEntry {
         access_flags: MethodAccessFlags::from_bits(
             (MethodAccessFlag::PUBLIC | MethodAccessFlag::STATIC).bits(),
         )
@@ -97,10 +97,10 @@ pub fn visit_system(class: Arc<LoadedClassFile>) {
 }
 
 pub fn visit_shutdown(class: Arc<LoadedClassFile>) {
-    let m = *class
-        .methods
-        .read()
-        .entries
+    let mut lock = class.methods.write();
+    let entries = &mut lock.entries;
+
+    let m = entries
         .iter()
         .enumerate()
         .filter(|(_i, p)| p.name.str == "<clinit>")
@@ -109,9 +109,9 @@ pub fn visit_shutdown(class: Arc<LoadedClassFile>) {
         .first()
         .unwrap();
 
-    class.methods.write().entries.remove(m);
+    entries.remove(m);
 
-    class.methods.write().entries.push(Arc::new(MethodEntry {
+    entries.push(Arc::new(MethodEntry {
         access_flags: MethodAccessFlags::from_bits(
             (MethodAccessFlag::PUBLIC | MethodAccessFlag::STATIC).bits(),
         )
@@ -136,10 +136,7 @@ pub fn visit_shutdown(class: Arc<LoadedClassFile>) {
         },
     }));
 
-    let m = *class
-        .methods
-        .read()
-        .entries
+    let m = entries
         .iter()
         .enumerate()
         .filter(|(_i, p)| p.name.str == "exit")
@@ -148,9 +145,9 @@ pub fn visit_shutdown(class: Arc<LoadedClassFile>) {
         .first()
         .unwrap();
 
-    class.methods.write().entries.remove(m);
+    entries.remove(m);
 
-    class.methods.write().entries.push(Arc::new(MethodEntry {
+    entries.push(Arc::new(MethodEntry {
         access_flags: MethodAccessFlags::from_bits(
             (MethodAccessFlag::PUBLIC | MethodAccessFlag::STATIC | MethodAccessFlag::NATIVE).bits(),
         )

--- a/src/structs/bitflag.rs
+++ b/src/structs/bitflag.rs
@@ -11,16 +11,13 @@ macro_rules! impl_flags {
 
         impl $impl_type {
             pub fn from_bits(raw: u16) -> Result<Self> {
-                let mut flags = <$flag_type>::from_bits(raw);
-
-                if flags.is_none() {
+                let flags = <$flag_type>::from_bits(raw);
+                let flags = flags.unwrap_or_else(|| {
                     warn!("unrecognised bits {:b} for {}", raw, stringify!($flag_type));
-                    flags = Some(<$flag_type>::from_bits_truncate(raw));
-                }
+                    <$flag_type>::from_bits_truncate(raw)
+                });
 
-                Ok(Self {
-                    flags: flags.unwrap(),
-                })
+                Ok(Self { flags })
             }
 
             pub fn has(&self, other: $flag_type) -> bool {

--- a/src/structs/descriptor.rs
+++ b/src/structs/descriptor.rs
@@ -148,14 +148,12 @@ impl<'a> Parser<'a> {
     }
 }
 
-/*
-    Examples:
-    (Ljava/lang/String;)V - 1 parameter, a reference type of java/lang/String
-    with a return type of void
-
-    (IDLjava/lang/Thread;)Ljava/lang/Object; - 3 parameters, int, double and reference type java/lang/Thread
-    with a return type of reference type java/lang/Object
-*/
+// Examples:
+// (Ljava/lang/String;)V - 1 parameter, a reference type of java/lang/String
+// with a return type of void
+//
+// (IDLjava/lang/Thread;)Ljava/lang/Object; - 3 parameters, int, double and reference type java/lang/Thread
+// with a return type of reference type java/lang/Object
 
 #[derive(Clone, Debug)]
 pub struct MethodDescriptor {
@@ -227,14 +225,12 @@ impl ToString for MethodDescriptor {
 }
 
 pub fn test_descriptor_parsing() {
-    /*
-        one_array_param:([Ljava/lang/String;)V
-        two_array_params:([Ljava/lang/String;[Ljava/lang/String;)V
-        one_two_darray_param:([[Ljava/lang/String;)V
-        one_three_darray_param:([[[Ljava/lang/String;)V
-        one_ref_param:(Ljava/lang/String;)V
-        two_ref_params:(Ljava/lang/String;Ljava/lang/String;)V
-    */
+    // one_array_param:([Ljava/lang/String;)V
+    // two_array_params:([Ljava/lang/String;[Ljava/lang/String;)V
+    // one_two_darray_param:([[Ljava/lang/String;)V
+    // one_three_darray_param:([[[Ljava/lang/String;)V
+    // one_ref_param:(Ljava/lang/String;)V
+    // two_ref_params:(Ljava/lang/String;Ljava/lang/String;)V
 
     let one_array_param = "([Ljava/lang/String;)V";
     let two_array_params = "([Ljava/lang/String;[Ljava/lang/String;)V";

--- a/src/structs/descriptor.rs
+++ b/src/structs/descriptor.rs
@@ -87,10 +87,10 @@ impl<'a> Parser<'a> {
             self.consume_next()?;
         }
 
-        let _type = self.parse_descriptor_type()?;
+        let type_ = self.parse_descriptor_type()?;
 
         Ok(DescriptorArrayType {
-            _type: Box::new(_type),
+            type_: Box::new(type_),
             dimensions: count,
         })
     }
@@ -186,10 +186,10 @@ impl FieldDescriptor {
         debug!("parsing field descriptor {}", descriptor);
         let mut parser = Parser::new(descriptor);
 
-        let _type = parser.parse_descriptor_type()?;
+        let type_ = parser.parse_descriptor_type()?;
 
         Ok(Self {
-            _type,
+            _type: type_,
             raw: parser.raw,
         })
     }
@@ -205,7 +205,7 @@ pub enum DescriptorType {
 
 #[derive(PartialEq, Debug, Clone)]
 pub struct DescriptorArrayType {
-    pub _type: Box<DescriptorType>,
+    pub type_: Box<DescriptorType>,
     pub dimensions: u16,
 }
 

--- a/src/structs/descriptor.rs
+++ b/src/structs/descriptor.rs
@@ -127,23 +127,14 @@ impl<'a> Parser<'a> {
     }
 
     fn consume_next(&mut self) -> Result<char> {
-        let next = self.chars.next();
-
-        if next.is_none() {
-            return Err(anyhow!("out of chars"));
-        }
-
-        Ok(next.unwrap())
+        self.chars.next().ok_or_else(|| anyhow!("out of chars"))
     }
 
     fn peek_next(&mut self) -> Result<char> {
-        let next = self.chars.peek();
-
-        if next.is_none() {
-            return Err(anyhow!("out of chars"));
-        }
-
-        Ok(*next.unwrap())
+        self.chars
+            .peek()
+            .copied()
+            .ok_or_else(|| anyhow!("out of chars"))
     }
 
     fn expect_next(&mut self, expect: char) -> Result<()> {

--- a/src/structs/loaded/attribute.rs
+++ b/src/structs/loaded/attribute.rs
@@ -7,11 +7,6 @@ pub struct Attributes {
 
 impl Attributes {
     pub fn get(&self, key: &str) -> Option<&AttributeEntry> {
-        self.entries
-            .iter()
-            .filter(|a| a.name().str == key)
-            .collect::<Vec<&AttributeEntry>>()
-            .first()
-            .copied()
+        self.entries.iter().find(|a| a.name().str == key)
     }
 }

--- a/src/structs/loaded/classfile.rs
+++ b/src/structs/loaded/classfile.rs
@@ -121,7 +121,7 @@ impl LoadedClassFile {
             methods,
             constructors,
             attributes,
-            package: None, //TODO: implement packages
+            package: None, // TODO: implement packages
             has_clinit_called: AtomicBool::new(false),
         })
     }

--- a/src/structs/loaded/classfile.rs
+++ b/src/structs/loaded/classfile.rs
@@ -146,17 +146,19 @@ impl LoadedClassFile {
 
         let clinit = self.methods.read().find(|m| m.name.str == "<clinit>");
 
-        if clinit.is_none() {
+        let clinit = if let Some(clinit) = clinit {
+            clinit
+        } else {
             warn!("clinit not found for {}", self.this_class.name.str);
             return Ok(());
-        }
+        };
 
         debug!("storing clinit state {}", self.this_class.name.str);
         self.has_clinit_called.store(true, Ordering::Release);
 
         debug!("calling clinit for {}", self.this_class.name.str);
         let res = vm.interpret(
-            CallSite::new(Arc::clone(self), ctx.thread, clinit.unwrap(), None),
+            CallSite::new(Arc::clone(self), ctx.thread, clinit, None),
             Args { entries: vec![] }, // empty args for clinit. it cannot take args, it is a class initialiser
             false,
         );

--- a/src/structs/loaded/classfile.rs
+++ b/src/structs/loaded/classfile.rs
@@ -81,7 +81,7 @@ impl LoadedClassFile {
 
             debug!("class has a superclass, {}", entry.name.str);
         } else {
-            debug!("class has no superclass")
+            debug!("class has no superclass");
         }
 
         let interfaces = create_interfaces(raw.interface_info, &const_pool)?;
@@ -90,10 +90,10 @@ impl LoadedClassFile {
             debug!("class as {} superinterfaces", interfaces.entries.len());
 
             for interface in &interfaces.entries {
-                debug!("\t{}", interface.name.str)
+                debug!("\t{}", interface.name.str);
             }
         } else {
-            debug!("class has no superinterfaces")
+            debug!("class has no superinterfaces");
         }
 
         let fields = RwLock::new(create_fields(raw.field_info, &const_pool)?);

--- a/src/structs/loaded/classfile_helper.rs
+++ b/src/structs/loaded/classfile_helper.rs
@@ -274,7 +274,7 @@ pub fn create_interfaces(raw: Vec<u16>, const_pool: &ConstantPool) -> Result<Int
         let entry = const_pool.class(idx as usize)?;
 
         //TODO: attach a classloader here and load the entries class so that we can validate it is an interface
-        out.entries.push(Arc::clone(&entry))
+        out.entries.push(Arc::clone(&entry));
     }
 
     Ok(out)
@@ -307,7 +307,7 @@ pub fn create_fields(raw: Vec<RawFieldEntry>, const_pool: &ConstantPool) -> Resu
             name,
             descriptor,
             attributes,
-        })
+        });
     }
     Ok(out)
 }
@@ -364,7 +364,7 @@ pub fn create_attributes(
             }
         };
 
-        out.entries.push(data)
+        out.entries.push(data);
     }
     Ok(out)
 }

--- a/src/structs/loaded/classfile_helper.rs
+++ b/src/structs/loaded/classfile_helper.rs
@@ -349,7 +349,6 @@ pub fn create_attributes(
         let name = const_pool.utf8(entry.attribute_name_index as usize)?;
         let name = Arc::clone(&name);
 
-
         let data = match name.str.as_str() {
             "Code" => AttributeEntry::Code(CodeData::from_bytes(
                 name,

--- a/src/structs/loaded/classfile_helper.rs
+++ b/src/structs/loaded/classfile_helper.rs
@@ -42,7 +42,7 @@ impl ConstantPoolBuilder {
 
     // attempt to resolve a string, will transform where possible
     fn string(&self, idx: u16) -> Result<Arc<Utf8Data>> {
-        return if let Some(data) = self.entries.get(&(idx as usize)) {
+        if let Some(data) = self.entries.get(&(idx as usize)) {
             if let LoadedPoolData::Utf8(data) = &data.data {
                 Ok(Arc::clone(data))
             } else {
@@ -50,31 +50,23 @@ impl ConstantPoolBuilder {
             }
         } else {
             let raw = self.raw.get(idx as usize);
+            let raw = raw.ok_or_else(|| anyhow!("pool entry {} did not exist", idx))?;
+            let raw = raw
+                .as_ref()
+                .ok_or_else(|| anyhow!("pool entry {} did not exist", idx))?;
 
-            if raw.is_none() {
-                return Err(anyhow!("pool entry {} did not exist", idx));
-            }
-
-            let raw = raw.unwrap();
-
-            if raw.is_none() {
-                return Err(anyhow!("pool entry {} did not exist", idx));
-            }
-
-            let raw = raw.as_ref().unwrap();
-
-            return if let RawPoolData::Utf8(data) = &raw.data {
+            if let RawPoolData::Utf8(data) = &raw.data {
                 Ok(Arc::new(Utf8Data {
                     str: String::from_utf8(data.bytes.clone())?,
                 }))
             } else {
                 Err(anyhow!("pool entry {} was not utf8", idx))
-            };
-        };
+            }
+        }
     }
 
     fn class(&self, idx: u16) -> Result<Arc<ClassData>> {
-        return if let Some(data) = self.entries.get(&(idx as usize)) {
+        if let Some(data) = self.entries.get(&(idx as usize)) {
             if let LoadedPoolData::Class(data) = &data.data {
                 Ok(Arc::clone(data))
             } else {
@@ -82,31 +74,23 @@ impl ConstantPoolBuilder {
             }
         } else {
             let raw = self.raw.get(idx as usize);
+            let raw = raw.ok_or_else(|| anyhow!("pool entry {} did not exist", idx))?;
+            let raw = raw
+                .as_ref()
+                .ok_or_else(|| anyhow!("pool entry {} did not exist", idx))?;
 
-            if raw.is_none() {
-                return Err(anyhow!("pool entry {} did not exist", idx));
-            }
-
-            let raw = raw.unwrap();
-
-            if raw.is_none() {
-                return Err(anyhow!("pool entry {} did not exist", idx));
-            }
-
-            let raw = raw.as_ref().unwrap();
-
-            return if let RawPoolData::Class(data) = &raw.data {
+            if let RawPoolData::Class(data) = &raw.data {
                 Ok(Arc::new(ClassData {
                     name: self.string(data.name_index)?,
                 }))
             } else {
                 Err(anyhow!("raw pool entry {} was not class", idx))
-            };
-        };
+            }
+        }
     }
 
     fn name_and_type(&self, idx: u16) -> Result<Arc<NameAndTypeData>> {
-        return if let Some(data) = self.entries.get(&(idx as usize)) {
+        if let Some(data) = self.entries.get(&(idx as usize)) {
             if let LoadedPoolData::NameAndType(data) = &data.data {
                 Ok(Arc::clone(data))
             } else {
@@ -114,28 +98,20 @@ impl ConstantPoolBuilder {
             }
         } else {
             let raw = self.raw.get(idx as usize);
+            let raw = raw.ok_or_else(|| anyhow!("pool entry {} did not exist", idx))?;
+            let raw = raw
+                .as_ref()
+                .ok_or_else(|| anyhow!("pool entry {} did not exist", idx))?;
 
-            if raw.is_none() {
-                return Err(anyhow!("pool entry {} did not exist", idx));
-            }
-
-            let raw = raw.unwrap();
-
-            if raw.is_none() {
-                return Err(anyhow!("pool entry {} did not exist", idx));
-            }
-
-            let raw = raw.as_ref().unwrap();
-
-            return if let RawPoolData::NameAndType(data) = &raw.data {
+            if let RawPoolData::NameAndType(data) = &raw.data {
                 Ok(Arc::new(NameAndTypeData {
                     name: self.string(data.name_index)?,
                     descriptor: self.string(data.descriptor_index)?,
                 }))
             } else {
                 Err(anyhow!("raw pool entry {} was not nameandtype", idx))
-            };
-        };
+            }
+        }
     }
 
     fn method_handle_reference(

--- a/src/structs/loaded/classfile_helper.rs
+++ b/src/structs/loaded/classfile_helper.rs
@@ -38,7 +38,7 @@ impl ConstantPoolBuilder {
         LoadedPoolEntry { tag, data }
     }
 
-    //TODO: reduce this duplication
+    // TODO: reduce this duplication
 
     // attempt to resolve a string, will transform where possible
     fn string(&self, idx: u16) -> Result<Arc<Utf8Data>> {
@@ -272,7 +272,7 @@ pub fn create_interfaces(raw: Vec<u16>, const_pool: &ConstantPool) -> Result<Int
     for idx in raw {
         let entry = const_pool.class(idx as usize)?;
 
-        //TODO: attach a classloader here and load the entries class so that we can validate it is an interface
+        // TODO: attach a classloader here and load the entries class so that we can validate it is an interface
         out.entries.push(Arc::clone(&entry));
     }
 

--- a/src/structs/loaded/classfile_helper.rs
+++ b/src/structs/loaded/classfile_helper.rs
@@ -238,8 +238,7 @@ impl ConstantPoolBuilder {
 
             // special casing for longs and doubles
             let to_inc = match &loaded.tag {
-                Tag::Long => 2,
-                Tag::Double => 2,
+                Tag::Long | Tag::Double => 2,
                 _ => 1,
             };
 
@@ -350,18 +349,17 @@ pub fn create_attributes(
         let name = const_pool.utf8(entry.attribute_name_index as usize)?;
         let name = Arc::clone(&name);
 
-        let data = match name.str.as_str() {
-            "Code" => AttributeEntry::Code(CodeData::from_bytes(
+        let data = if &name.str == "Code" {
+            AttributeEntry::Code(CodeData::from_bytes(
                 name,
                 entry.attribute_data,
                 const_pool,
-            )?),
-            _ => {
-                warn!("unrecognised attribute '{}'", name.str);
+            )?)
+        } else {
+            warn!("unrecognised attribute '{}'", name.str);
 
-                // ignore attributes we dont recognise
-                continue;
-            }
+            // ignore attributes we dont recognise
+            continue;
         };
 
         out.entries.push(data);

--- a/src/structs/loaded/classfile_helper.rs
+++ b/src/structs/loaded/classfile_helper.rs
@@ -349,17 +349,20 @@ pub fn create_attributes(
         let name = const_pool.utf8(entry.attribute_name_index as usize)?;
         let name = Arc::clone(&name);
 
-        let data = if &name.str == "Code" {
-            AttributeEntry::Code(CodeData::from_bytes(
+
+        let data = match name.str.as_str() {
+            "Code" => AttributeEntry::Code(CodeData::from_bytes(
                 name,
                 entry.attribute_data,
                 const_pool,
-            )?)
-        } else {
-            warn!("unrecognised attribute '{}'", name.str);
+            )?),
+            _ => {
+                // TODO: Implement standard attributes.
+                warn!("unrecognised attribute '{}'", name.str);
 
-            // ignore attributes we dont recognise
-            continue;
+                // ignore attributes we dont recognise
+                continue;
+            }
         };
 
         out.entries.push(data);

--- a/src/structs/loaded/constant_pool.rs
+++ b/src/structs/loaded/constant_pool.rs
@@ -132,14 +132,14 @@ pub struct MethodTypeData {
 #[derive(Clone, Debug)]
 pub struct DynamicData {
     pub bootstrap_method_attr_index: u16,
-    //TODO: resolve this when attribute parsing is implemented
+    // TODO: resolve this when attribute parsing is implemented
     pub name_and_type: Arc<NameAndTypeData>,
 }
 
 #[derive(Clone, Debug)]
 pub struct InvokeDynamicData {
     pub bootstrap_method_attr_index: u16,
-    //TODO: resolve this when attribute parsing is implemented
+    // TODO: resolve this when attribute parsing is implemented
     pub name_and_type: Arc<NameAndTypeData>,
 }
 

--- a/src/structs/loaded/constant_pool.rs
+++ b/src/structs/loaded/constant_pool.rs
@@ -15,42 +15,29 @@ pub struct ConstantPool {
 impl ConstantPool {
     pub fn get(&self, idx: usize) -> Result<&PoolEntry> {
         let res = self.entries.get(&idx);
-
-        if res.is_none() {
-            return Err(anyhow!("pool entry {} does not exist", idx));
-        }
-
-        Ok(res.unwrap())
+        res.ok_or_else(|| anyhow!("pool entry {} does not exist", idx))
     }
 
     pub fn class(&self, idx: usize) -> Result<Arc<ClassData>> {
         let entry = self.get(idx)?.data.as_class();
+        let entry = entry.ok_or_else(|| anyhow!("constant pool entry {} was not a class", idx))?;
 
-        if entry.is_none() {
-            return Err(anyhow!("constant pool entry {} was not a class", idx));
-        }
-
-        Ok(Arc::clone(entry.unwrap()))
+        Ok(Arc::clone(entry))
     }
 
     pub fn utf8(&self, idx: usize) -> Result<Arc<Utf8Data>> {
         let entry = self.get(idx)?.data.as_utf8();
+        let entry = entry.ok_or_else(|| anyhow!("constant pool entry {} was not utf8", idx))?;
 
-        if entry.is_none() {
-            return Err(anyhow!("constant pool entry {} was not utf8", idx));
-        }
-
-        Ok(Arc::clone(entry.unwrap()))
+        Ok(Arc::clone(entry))
     }
 
     pub fn field(&self, idx: usize) -> Result<Arc<FieldRefData>> {
         let entry = self.get(idx)?.data.as_field_ref();
+        let entry = entry
+            .ok_or_else(|| anyhow!("constant pool entry {} was not a field reference", idx))?;
 
-        if entry.is_none() {
-            return Err(anyhow!("constant pool entry {} was not a class", idx));
-        }
-
-        Ok(Arc::clone(entry.unwrap()))
+        Ok(Arc::clone(entry))
     }
 
     pub fn has(&self, idx: usize) -> bool {

--- a/src/structs/loaded/default_attributes.rs
+++ b/src/structs/loaded/default_attributes.rs
@@ -67,7 +67,7 @@ impl CodeData {
                 data.push(bytes.try_get_u8()?);
             }
 
-            attributes.push(CustomData { name, data })
+            attributes.push(CustomData { name, data });
         }
 
         Ok(Self {

--- a/src/structs/loaded/default_attributes.rs
+++ b/src/structs/loaded/default_attributes.rs
@@ -52,7 +52,7 @@ impl CodeData {
                 end: bytes.try_get_u16()?,
                 handler: bytes.try_get_u16()?,
                 catch_type: bytes.try_get_u16()?,
-            })
+            });
         }
 
         let attribute_count = bytes.try_get_u16()?;

--- a/src/structs/raw/constant_pool.rs
+++ b/src/structs/raw/constant_pool.rs
@@ -82,14 +82,14 @@ pub struct FloatData {
 
 #[derive(Copy, Clone, Debug)]
 pub struct LongData {
-    //TODO: this has to take up 2 entries (?)
+    // TODO: this has to take up 2 entries (?)
     pub low_bytes: u32,
     pub high_bytes: u32,
 }
 
 #[derive(Copy, Clone, Debug)]
 pub struct DoubleData {
-    //TODO: this has to take up 2 entries (?)
+    // TODO: this has to take up 2 entries (?)
     pub low_bytes: f32,
     pub high_bytes: f32,
 }

--- a/src/structs/types.rs
+++ b/src/structs/types.rs
@@ -77,8 +77,3 @@ impl RefOrPrim {
         }
     }
 }
-
-/*
-ReferenceType::Class(c) => DescriptorType::Reference(DescriptorReferenceType { internal_name: "".to_string() }).
-                ReferenceType::Null => None
- */


### PR DESCRIPTION
## Confirmation
- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines](https://github.com/nullishamy/JVM/blob/main/CONTRIBUTING.MD)

### Changes

- [x] Internal
- [ ] Feature
- [ ] Documentation
- [ ] Other: \_____ 

<!-- Replace "NaN" with an issue number (in the #123 format) if this is a response to an issue -->

Closes Issue: NaN

## Description

Various style improvements

- Improved error handling, less `unwrap`
- Semicolon consistency
- Re-use locks, drop some locks earlier (could this somehow cause deadlocks or races?)
- Algorithm improvements (make use of `Vec::retain` and `Iterator::find`)
- Make use of nested OR-patterns
- Other small style changes in 2b247f01ff57f418c1207f61da36031fdbdd6f7f
- Adds `FIXME` for a logic error in `util.rs`

TODOs:

- [x] In `heap/mod.rs` / `Heap::prune`, can we find a better way to assign `counter`?
- [x] Are the API changes in da6cd2735fa0ae902ea6952d119fda1351a1b1a1 reasonable? (in particular the changes to `Stack::flip`)
- [x] Is there a logic error in `areturn.rs`? (see the `TODO`)
- [x] Potentially avoid block comments as per [RFC 1574](https://github.com/rust-lang/rfcs/blob/master/text/1574-more-api-documentation-conventions.md#use-line-comments)
- [x] Replace `_keyword` variable/field names with something like `keyword_`
- [x] Test that this doesn't break anything