### PR TITLE
Try reading from filename without `.class` added 

### DIFF
--- a/src/classfile/parse.rs
+++ b/src/classfile/parse.rs
@@ -3,7 +3,7 @@ use std::io::{ErrorKind, Read};
 
 use anyhow::{anyhow, Result};
 use bytes::Bytes;
-use tracing::{debug, info, warn};
+use tracing::{debug, info};
 
 use crate::classfile::parse_helper::{
     parse_attribute_info, parse_const_pool, parse_field_info, parse_interface_info,


### PR DESCRIPTION
## Confirmation
- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines](https://github.com/nullishamy/JVM/blob/main/CONTRIBUTING.MD)

### Changes

- [x] Internal
- [ ] Feature
- [ ] Documentation
- [ ] Other: \_____ 

<!-- Replace "NaN" with an issue number (in the #123 format) if this is a response to an issue -->

Closes Issue: NaN

## Description

Previously the CLI expected the filename to be like `examples/ExitCode` and it would add the `.class` extension itself. But this interferes with shell autocompletion as shells would include the file extension. This PR fixes this inconvenience by trying to load the file without `.class` added to the end if the first attempt at reading it returns a `ErrorKind::NotFound`.
